### PR TITLE
fix respense with PATHNAME.

### DIFF
--- a/src/woo.lisp
+++ b/src/woo.lisp
@@ -247,6 +247,7 @@
         clack-res
       (when (eq body no-body)
         (setf (getf headers :transfer-encoding) "chunked")
+        (setf (getf headers :content-length) nil)
         (wev:with-async-writing (socket)
           (write-response-headers socket status headers))
         (return-from handle-normal-response
@@ -266,6 +267,7 @@
            (write-response-headers socket status headers (not close))))
         (pathname
          (setf (getf headers :transfer-encoding) "chunked")
+         (setf (getf headers :content-length) nil)
          (wev:with-async-writing (socket :write-cb (and close
                                                         (lambda (socket)
                                                           (wev:close-socket socket))))


### PR DESCRIPTION
http://httpwg.github.io/specs/rfc7230.html#header.content-length
> A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.