### PR TITLE
* Fix bug : socket were not closed after shutdown

### DIFF
--- a/src/ev/socket.lisp
+++ b/src/ev/socket.lisp
@@ -117,6 +117,7 @@
   (free-watchers socket)
   (let ((fd (socket-fd socket)))
     (wsock:shutdown fd wsock:+SHUT-RDWR+)
+    (wsock:close-socket fd)
     (remove-pointer-from-registry fd))
   (setf (socket-open-p socket) nil
         (socket-read-cb socket) nil

--- a/src/llsocket/cffi.lisp
+++ b/src/llsocket/cffi.lisp
@@ -83,6 +83,10 @@
   (socket :int)
   (how :int))
 
+(cffi:defcfun ("close" close-socket) :int
+  (socket :int))
+
+
 (cffi:defcfun ("socket" socket) :int
   (domain :int)  ;; +AF-*+
   (type :int)    ;; +SOCK-*+

--- a/src/llsocket/package.lisp
+++ b/src/llsocket/package.lisp
@@ -96,6 +96,7 @@
            :sendmsg
            :setsockopt
            :shutdown
+	   :close-socket
            :socket
            :socketpair))
 (in-package :woo.llsocket)


### PR DESCRIPTION
Hi,

First, thanks for *woo*, which, even though being in alpha state, seems quite promising :)

In my company, we are collecting data from various energy infrastructures, at a very hight rate. The current open source time-serie databases are not fast enough for our requirement.

Therefore we are developping our own technology, and as data are recorded using http request, we want to optimize this part as well.

And woo seems a good candidate. So I've integrated it in our solution, and I've discovered a small bug. With this simple code:

```
(woo:run
  (lambda (env)
    (declare (ignore env))
    '(200 (:content-type "text/plain") ("Hello, World"))))
```

Each time you make a request using

```
# curl -X GET http://localhost:5000/
```
a new socket is created, shudowned, *but not closed* ! 

If you use *lsof* to the the number of file open by your favorite lisp environment : 

```
# lsof -p mySbclPid |wc
```
You'll see that they augment after each http request.

I provide in this merge request a few changes that fix this issue.

Regards,

Guillaume

