### PR TITLE
* Fix error on ntoa : support for 64 bit address

### DIFF
--- a/src/llsocket/cffi.lisp
+++ b/src/llsocket/cffi.lisp
@@ -40,7 +40,7 @@
   (optlen :int))
 
 (cffi:defcfun ("inet_ntoa" inet-ntoa) :string
-  (addr :int))
+  (addr :int64))
 
 (cffi:defcfun ("listen" listen) :int
   (socket :int)


### PR DESCRIPTION
The value 3941122772 is not of type (SIGNED-BYTE 32).
Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE] Ignore runtime option --eval "****".
  1: [ABORT   ] Skip rest of --eval and --load options.
  2:            Skip to toplevel READ/EVAL/PRINT loop.
  3: [EXIT    ] Exit SBCL (calling #'EXIT, killing the process).

(WOO.LLSOCKET:INET-NTOA 3941122772)