### PR TITLE
Fix brokenness on FreeBSD

### DIFF
--- a/src/syscall/main.lisp
+++ b/src/syscall/main.lisp
@@ -127,7 +127,7 @@
           -1
           (cffi:mem-aref len 'off-t))))
   #+freebsd
-  (cffi:with-foreign-slots (sbytes 'off-t)
+  (cffi:with-foreign-object (sbytes 'off-t)
     (let ((retval (%sendfile infd outfd offset nbytes (cffi:null-pointer) sbytes +SF-MNOWAIT+)))
       (declare (type fixnum retval))
       (if (= retval -1)


### PR DESCRIPTION
With `sbcl` on FreeBSD, `(ql:quickload :woo)` fails with:

    ; file: quicklisp/dists/quicklisp/software/woo-20151031-git/src/syscall/main.lisp
    ; in: DEFUN SENDFILE
    ;     (CFFI:WITH-FOREIGN-SLOTS (WOO.SYSCALL::SBYTES 'WOO.SYSCALL::OFF-T)
    ;       (LET ((WOO.SYSCALL::RETVAL
    ;              (WOO.SYSCALL::%SENDFILE WOO.SYSCALL::INFD WOO.SYSCALL::OUTFD
    ;               WOO.SYSCALL::OFFSET WOO.SYSCALL::NBYTES # WOO.SYSCALL::SBYTES
    ;               WOO.SYSCALL::+SF-MNOWAIT+)))
    ;         (DECLARE (TYPE FIXNUM WOO.SYSCALL::RETVAL))
    ;         (IF (= WOO.SYSCALL::RETVAL -1)
    ;             -1
    ;             (CFFI:MEM-AREF WOO.SYSCALL::SBYTES 'WOO.SYSCALL::OFF-T))))
    ; 
    ; caught ERROR:
    ;   during macroexpansion of
    ;   (CFFI:WITH-FOREIGN-SLOTS (SBYTES 'OFF-T)
    ;     (LET #
    ;       #
    ;       ...)).
    ;   Use *BREAK-ON-SIGNALS* to intercept.
    ;   
    ;    error while parsing arguments to DEFMACRO CFFI:WITH-FOREIGN-SLOTS:
    ;      too few elements in
    ;        (SBYTES 'OFF-T)
    ;      to satisfy lambda list
    ;        (CFFI::VARS CFFI::PTR TYPE):
    ;      exactly 3 expected, but got 2
    
    debugger invoked on a UIOP/LISP-BUILD:COMPILE-FILE-ERROR in thread
    #<THREAD "main thread" RUNNING {1002AE4A03}>:
      COMPILE-FILE-ERROR while
      compiling #<CL-SOURCE-FILE "woo" "src" "syscall" "main">

The attached commit diff fixes this.

Thanks!