### PR TITLE
handle-response: make etypecase more specific

### DIFF
--- a/src/woo.lisp
+++ b/src/woo.lisp
@@ -305,10 +305,20 @@
 ;;
 ;; Handling responses
 
+(deftype http-status ()
+  '(integer 100 599))
+
+(deftype http-body ()
+  '(or list (vector (unsigned-byte 8)) pathname))
+
+(deftype clack-response ()
+  '(cons http-status (cons list (or (cons http-body null)
+                                 null))))
+
 (defun handle-response (http socket clack-res)
   (handler-case
       (etypecase clack-res
-        (list (handle-normal-response http socket clack-res))
+        (clack-response (handle-normal-response http socket clack-res))
         (function (funcall clack-res (lambda (clack-res)
                                        (handler-case
                                            (handle-normal-response http socket clack-res)


### PR DESCRIPTION
Hi,
  currently handle-response only tests if the response returned is a list. () satifies that constraint and an error is signaled down the line in handle-normal-response when trying to destructuring-bind the malformed response. It would be a good idea to fail earlier with a clear error. The type definitions could be placed in clack as they could be useful for other handlers and users.