### PR TITLE
Specify :lenient T when decoding URL path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   # for Clack.Test
   - ros install fukamachi/clack
   - ros install fukamachi/dexador
-  # for ipv6-address-p
+  # for ipv6-address-p & lenient url-decode
   - ros install fukamachi/quri
 
 before_script:

--- a/src/woo.lisp
+++ b/src/woo.lisp
@@ -22,8 +22,7 @@
   (:import-from :quri
                 :uri
                 :uri-path
-                :uri-query
-                :uri-error)
+                :uri-query)
   (:import-from :fast-http
                 :make-http-request
                 :make-parser
@@ -235,9 +234,7 @@
                   :server-port (or server-port 80)
                   :server-protocol (http-version-keyword (http-major-version http) (http-minor-version http))
                   :path-info (and path
-                                  (handler-case (quri:url-decode path)
-                                    (quri:uri-error ()
-                                      path)))
+                                  (quri:url-decode path :lenient t))
                   :query-string query
                   :url-scheme "http"
                   :remote-addr (socket-remote-addr socket)


### PR DESCRIPTION
This requires the latest QURI.

refs https://github.com/fukamachi/lack/issues/21