### PR TITLE
Benchmark Racket web server

### DIFF
--- a/benchmark.md
+++ b/benchmark.md
@@ -27,6 +27,7 @@ The benchmarking environment is:
 * Quicklisp 2016-08-25
 * Node.js 4.2.6
 * Go 1.6.2
+* Racket 6.12
 * Ruby 2.3.1p112
 * Unicorn 5.1.0
 * libuv 1.8.0
@@ -35,7 +36,7 @@ The benchmarking environment is:
 ```
 $ cat /proc/version
 Linux version 4.4.0-36-generic (buildd@lcy01-01) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.2) ) #55-Ubuntu SMP Thu Aug 11 18:01:55 UTC 2016
-$ sudo apt-get install wrk nginx python2.7 python-pip pypy nodejs golang ruby ruby-dev libuv1-dev libev-dev
+$ sudo apt-get install wrk nginx python2.7 python-pip pypy nodejs golang racket ruby ruby-dev libuv1-dev libev-dev
 $ sudo apt-get install -y autotools-dev automake libcurl4-gnutls-dev curl make
 $ pip install tornado
 $ sudo gem install unicorn rack
@@ -380,4 +381,32 @@ Running 10s test @ http://127.0.0.1:5000
   1064894 requests in 10.04s, 131.01MB read
 Requests/sec: 106036.86
 Transfer/sec:     13.05MB
+```
+
+## Racket
+
+```
+$ benchmark/run-benchmark benchmark/racket/run
+```
+
+``` 
+Running 10s test @ http://127.0.0.1:5000
+  4 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     6.51ms   13.02ms 147.67ms   91.74%
+    Req/Sec   561.37    131.01   808.00     64.65%
+  22335 requests in 10.06s, 3.22MB read
+Requests/sec:   2219.30
+Transfer/sec:    327.26KB
+```
+
+```
+Running 10s test @ http://127.0.0.1:5000
+  4 threads and 100 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    66.70ms   52.98ms 503.75ms   89.11%
+    Req/Sec   434.91    179.08   700.00     62.37%
+  17013 requests in 10.06s, 2.45MB read
+Requests/sec:   1691.04
+Transfer/sec:    249.36KB
 ```

--- a/benchmark/racket/hello.rkt
+++ b/benchmark/racket/hello.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+
+(require
+ (only-in web-server/http
+          response/full)
+ (only-in web-server/http/request-structs
+          make-header)
+ (only-in web-server/servlet-env
+          serve/servlet))
+
+(define fixed-response
+  (response/full
+   200                          ;; code
+   (string->bytes/utf-8 "OK")   ;; message
+   (current-seconds)            ;; timestamp in s
+   #f                           ;; mime or #f
+   (list (make-header           ;; list of headers
+          (string->bytes/utf-8 "Server")
+          (string->bytes/utf-8 "Racket")))
+   (list                        ;; body: list of bytes
+    (string->bytes/utf-8 "Hello world!\n"))))
+
+;; hello: request? -> response?
+(define (hello req)
+  fixed-response)
+
+(module+ main
+  (serve/servlet
+   hello
+   #:port 5000
+   #:command-line? #t
+   #:servlet-regexp #rx""))

--- a/benchmark/racket/run
+++ b/benchmark/racket/run
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+BASEDIR=$(dirname $0)
+WORKER=${1:-1}
+
+exec racket "$BASEDIR/hello.rkt"

--- a/benchmark/racket/typed-hello.rkt
+++ b/benchmark/racket/typed-hello.rkt
@@ -1,0 +1,56 @@
+#lang typed/racket/base
+
+(require/typed net/url-structs
+  [#:struct path/param
+   ([path : (U String (U 'up 'same))]
+    [param : (Listof String)])]
+  [#:struct url
+   ([scheme : (U False String)]
+    [user : (U False String)]
+    [host : (U False String)]
+    [port : (U False Exact-Nonnegative-Integer)]
+    [path-absolute? : Boolean]
+    [path : (Listof path/param)]
+    [query : (Listof (Pairof Symbol (U False String)))]
+    [fragment : (U False String)])])
+(require/typed web-server/http
+  [#:struct header
+   ([field : Bytes]
+    [value : Bytes])]
+  [#:struct binding
+   ([id : Bytes])]
+  [#:struct request
+   ([method : Bytes]
+    [uri : url]
+    [headers/raw : (Listof header)]
+    [bindings/raw-promise : (Promise (Listof binding))]
+    [post-data/raw : (U False Bytes)]
+    [host-ip : String]
+    [host-port : Number]
+    [client-ip : String])]
+  [#:struct response
+   ([code : Number]
+    [message : Bytes]
+    [seconds : Number]
+    [mime : (U False Bytes)]
+    [headers : (Listof Bytes)]
+    [output : (-> Boolean Any)])]
+  [response/output (-> (-> Output-Port Void) response)])
+
+
+(: hello (-> request response))
+(define (hello req)
+  (response/output (lambda (out) (display "Hello world!\n" out))))
+
+(module+ main
+  (require/typed web-server/servlet-env
+    [serve/servlet (-> (-> request response)
+                        (#:port Number)
+                        (#:command-line? Boolean)
+                        (#:servlet-regexp Regexp)
+                        Void)])
+  (serve/servlet
+   hello
+   #:port 5000
+   #:command-line? #t
+   #:servlet-regexp #rx""))


### PR DESCRIPTION
Adds a benchmark of the standard Racket web server. There are reported number in the `benchmarks.md` example run; they are intended as placeholders until this benchmark has run in a comparable setup to all other web servers.

Also, please note that this implementation is quite naïve and could probably be improved upon. Originally, I read your benchmarks and wanted to have comparable numbers for Racket. Then I thought about contributing back my benchmark.