### PR TITLE
Now if X-Forwarded-Proto header is received, we use it to set a scheme for the env

### DIFF
--- a/src/woo.lisp
+++ b/src/woo.lisp
@@ -214,9 +214,10 @@
             (values host nil))))))
 
 (defun handle-request (http socket)
-  (let ((host (gethash "host" (http-headers http)))
-        (headers (http-headers http))
-        (uri (http-resource http)))
+  (let* ((headers (http-headers http))
+         (host (gethash "host" headers))
+         (forwarded-proto (gethash "x-forwarded-proto" headers))
+         (uri (http-resource http)))
     (declare (type simple-string uri))
 
     (multiple-value-bind (scheme userinfo hostname port path query fragment)
@@ -234,7 +235,8 @@
               :path-info (and path
                               (quri:url-decode path :lenient t))
               :query-string query
-              :url-scheme "http"
+              :url-scheme (or forwarded-proto
+                              "http")
               :remote-addr (socket-remote-addr socket)
               :remote-port (socket-remote-port socket)
               :request-uri uri


### PR DESCRIPTION
The X-Forwarded-Proto header is a de-facto standard header for identifying the protocol (HTTP or HTTPS) that a client used to connect to your proxy or load balancer.

More details is at the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto

This pull should be merged with it's test from this pull request:

https://github.com/fukamachi/clack/pull/156