### PR TITLE
Ignore empty chunks in chunked body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ install:
   # wrk, go for benchmarking
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       curl -L "https://github.com/wg/wrk/archive/$WRK_VERSION.tar.gz" | tar xzf -;
-      (cd "wrk-$WRK_VERSION/" && make && cp wrk ~/.roswell/bin);
+      mkdir -p "$ROSWELL_INSTALL_DIR/bin";
+      (cd "wrk-$WRK_VERSION/" && make && cp wrk "$ROSWELL_INSTALL_DIR/bin");
       sudo apt-get install golang;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - ROSWELL_INSTALL_DIR=$HOME/.roswell
     - WRK_VERSION=4.0.2
   matrix:
-    - LISP=sbcl-bin
+    - LISP=sbcl
 
 addons:
   apt:
@@ -22,8 +22,6 @@ addons:
 install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libev; fi
   - curl -L https://raw.githubusercontent.com/snmsts/roswell/$ROSWELL_BRANCH/scripts/install-for-ci.sh | sh
-  # for thread-support on OS X
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ros install sbcl; fi
 
   # wrk, go for benchmarking
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/src/woo.lisp
+++ b/src/woo.lisp
@@ -360,7 +360,7 @@
                  (write-socket-crlf socket)
                  (loop for chunk in body
                        for data = (list-body-chunk-to-octets chunk)
-                       when data
+                       when (and data (/= 0 (length data)))
                          do (write-socket-string socket (the simple-string (format nil "~X" (length data))))
                             (write-socket-crlf socket)
                             (wev:write-socket-data socket data)

--- a/t/ipv6.lisp
+++ b/t/ipv6.lisp
@@ -11,7 +11,8 @@
 
 (plan 1)
 
-(let ((clack.test:*clackup-additional-args* '(:address "::")))
+(let ((clack.test:*clackup-additional-args* '(:address "::"))
+      (clack.test:*clack-test-handler* :woo))
   (subtest-app "IPv6"
       (lambda (env)
         (declare (ignore env))


### PR DESCRIPTION
The problem in #85 had been occured because an empty string (`""`) is in chunked response body and it accidentally terminates the chunked response.

This fixes it by ignoring empty strings while writing the chunked response.