### PR TITLE
changed freebsd feature check to include bsd

### DIFF
--- a/src/llsocket/grovel.lisp
+++ b/src/llsocket/grovel.lisp
@@ -1,4 +1,4 @@
-#+freebsd
+#+(or bsd freebsd)
 (progn
   (include "time.h")
   (include "sys/time.h"))

--- a/src/syscall/main.lisp
+++ b/src/syscall/main.lisp
@@ -106,7 +106,7 @@
   (len :pointer)
   (hdtr :pointer)
   (flags :int))
-#+freebsd
+#+(or freebsd bsd)
 (defcfun (%sendfile "sendfile") ssize-t
   (infd   :int)
   (outfd  :int)
@@ -129,12 +129,12 @@
       (if (= retval -1)
           -1
           (cffi:mem-aref len 'off-t))))
-  #+freebsd
+  #+(or freebsd bsd)
   (cffi:with-foreign-object (sbytes 'off-t)
     (let ((retval (%sendfile infd outfd offset nbytes (cffi:null-pointer) sbytes +SF-MNOWAIT+)))
       (declare (type fixnum retval))
       (if (= retval -1)
           -1
           (cffi:mem-aref sbytes 'off-t))))
-  #-(or linux darwin freebsd)
+  #-(or linux darwin freebsd bsd)
   (error "sendfile is not supported"))

--- a/src/syscall/types.lisp
+++ b/src/syscall/types.lisp
@@ -1,5 +1,5 @@
 (include "sys/types.h" "sys/fcntl.h")
-#+freebsd
+#+(or freebsd bsd)
 (include "sys/socket.h")
 
 (in-package :woo.syscall)
@@ -10,7 +10,7 @@
 (ctype off-t "off_t")
 (ctype mode-t "mode_t")
 
-#+freebsd
+#+(or freebsd bsd)
 (constant (+SF-MNOWAIT+ "SF_MNOWAIT"))
 
 (constant (+O-RDONLY+ "O_RDONLY"))


### PR DESCRIPTION
freebsd version of SBCL has `bsd` instead of `freebsd` in `*features*`

this PR adds `bsd` into the reader macro checks 