### PR TITLE
Create a new random state for each worker.

### DIFF
--- a/src/specials.lisp
+++ b/src/specials.lisp
@@ -14,7 +14,8 @@
   `((*standard-output* . ,*standard-output*)
     (*error-output* . ,*error-output*)
     (*app* . ,*app*)
-    (*debug* . ,*debug*)))
+    (*debug* . ,*debug*)
+    (*random-state* . ,(make-random-state t))))
 
 (defvar *listener* nil)
 (defvar *cluster* nil)


### PR DESCRIPTION
This prevents conflictions of `cl:random` in different worker threads.