### PR TITLE
Add default :content-type to static file responses

### DIFF
--- a/src/woo.lisp
+++ b/src/woo.lisp
@@ -145,7 +145,7 @@
   (error 'invalid-http-version
            :format-control "INVALID-HTTP-VERSION: major ~A minor ~A"
            :format-arguments (list major minor)))
-  
+
 (defun http-version-keyword (major minor)
   (unless (= major 1)
     (error-invalid-http-version major minor))
@@ -348,6 +348,8 @@
                       #-(or sbcl ccl) (file-size body)))
            (unless (getf headers :content-length)
              (setf (getf headers :content-length) size))
+           (unless (getf headers :content-type)
+             (setf (getf headers :content-type) (mimes:mime body)))
            (wev:with-async-writing (socket :write-cb (and close
                                                           (lambda (socket)
                                                             (wev:close-socket socket))))

--- a/woo.asd
+++ b/woo.asd
@@ -14,6 +14,7 @@
                "fast-io"
                "smart-buffer"
                "trivial-utf-8"
+               "trivial-mimes"
                "vom"
                "alexandria"
                #+sbcl "sb-posix"


### PR DESCRIPTION
Hey there,

Static file responses did not send a content-type if none was provided, I added a check that adds a content-type using trivial-mimes in that case which fixes some issues I was having.

Have a nice day,
Ben