### PR TITLE
Don't mutate a string literal

### DIFF
--- a/src/response.lisp
+++ b/src/response.lisp
@@ -129,7 +129,10 @@
   (wev:write-socket-data socket *crlf*))
 
 (declaim (type (simple-array character (29)) *date-header*))
-(defvar *date-header* "Thu, 01 Jan 1970 00:00:00 GMT")
+(defvar *date-header*
+  (make-array 29
+              :element-type 'character
+              :initial-contents "Thu, 01 Jan 1970 00:00:00 GMT"))
 
 (declaim (inline integer-to-character))
 (defun integer-to-character (int)


### PR DESCRIPTION
Mutating functions in `current-rfc-1123-timestamp` are used to modify the `*date-header*` variable, which was a string literal.

This was causing an `SB-SYS:MEMORY-FAULT-ERROR: Attempt to modify a read-only object` when running from an executable dumped with `sb-ext:save-lisp-and-die :executable :t`

I don't know how to add a test for this...

See https://github.com/NixOS/nixpkgs/issues/252016