### PR TITLE
Fixes to run on LispWorks.

### DIFF
--- a/src/ev/socket.lisp
+++ b/src/ev/socket.lisp
@@ -76,7 +76,7 @@
   (write-cb nil :type (or null function))
   (open-p t :type boolean)
 
-  (buffer (make-output-buffer))
+  (buffer (make-output-buffer #+lispworks :output #+lispworks :static))
   (sendfile-fd nil :type (or null fixnum))
   (sendfile-size nil :type (or null integer))
   (sendfile-offset 0 :type (or null integer)))

--- a/src/syscall/main.lisp
+++ b/src/syscall/main.lisp
@@ -81,12 +81,13 @@
 ;; errno(3) is not a C function in some environments (ex. Mac).
 ;; libfixposix can be a workaround for it, but I don't like to add a dependency on it
 ;; just for it.
-#+(or sbcl ccl)
+#+(or sbcl ccl lispworks)
 (declaim (ftype (function () fixnum) errno))
 (defun errno ()
   #+sbcl (sb-impl::get-errno)
   #+ccl (ccl::%get-errno)
-  #-(or sbcl ccl) nil)
+  #+lispworks (lw:errno-value)
+  #-(or sbcl ccl lispworks) nil)
 
 (defcfun (getpid "getpid") pid-t)
 

--- a/src/woo.lisp
+++ b/src/woo.lisp
@@ -289,7 +289,10 @@
     (unless successp
       (error "'fstat' failed"))
     size))
-#-(or sbcl ccl)
+#+lispworks
+(defun file-size (path)
+  (sys:file-size path))
+#-(or sbcl ccl lispworks)
 (defun file-size (path)
   (with-open-file (in path)
     (file-length in)))
@@ -344,8 +347,9 @@
            (write-response-headers socket status headers (not close))))
         (pathname
          (let* ((fd (wsys:open body))
-                (size #+(or sbcl ccl) (fd-file-size fd)
-                      #-(or sbcl ccl) (file-size body)))
+                (size #+lispworks (sys:file-size body)
+                      #+(or sbcl ccl) (fd-file-size fd)
+                      #-(or sbcl ccl lispworks) (file-size body)))
            (unless (getf headers :content-length)
              (setf (getf headers :content-length) size))
            (unless (getf headers :content-type)


### PR DESCRIPTION
Fixes fukamachi/woo#110 by ensuring the socket output buffer is allocated in a static segment as required by LispWorks' FLI. Modify `woo.syscall:errno` to support LispWorks via `sys:errno-value` to prevent comparison with `nil` in socket callbacks. These two changes are required for Woo to run on LispWorks.

This PR also makes use of `lw:file-size` to determine the length of a file. This is not essential, but an obvious optimisation to avoid opening files for the sole reason of determining their length.

All changes are conditionalised to LispWorks in keeping with existing code style and tested on Intel macOS 13.6.1 using LispWorks 8.0.1 Enterprise. This PR provides the bare minimum set of changes to permit starting a server and responding to requests. It does not fix other issues such as signal handling problems.