### PR TITLE
Add HTTPS support with OpenSSL (CL+SSL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           ROSWELL_INSTALL_DIR: /usr
         run: |
           curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
+      - name: Install Ultralisp
+        run: ros -e '(ql-dist:install-dist "http://dist.ultralisp.org/" :prompt nil)'
       - name: Install Rove
         run: ros install rove
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies from APT
         run: sudo apt-get install -y libev-dev gcc libc6-dev
+      - name: Generate server certificates
+        run: sh ./t/generate-certificates.sh
       - name: Install Roswell
         env:
           LISP: ${{ matrix.lisp }}
@@ -24,6 +26,8 @@ jobs:
         run: ros -e '(ql-dist:install-dist "http://dist.ultralisp.org/" :prompt nil)'
       - name: Install Rove
         run: ros install rove
+      - name: Install the latest Clack (for HTTPS testing with clack-test)
+        run: ros install fukamachi/clack
       - name: Run tests
         env:
           LISP: ${{ matrix.lisp }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ benchmark/benchmark.log
 .qlot/
 qlfile
 qlfile.lock
+t/certs/

--- a/src/ev/socket.lisp
+++ b/src/ev/socket.lisp
@@ -185,11 +185,15 @@
     (cffi:with-pointer-to-vector-data (data-sap data)
       (let* ((len (length data))
              (completedp nil)
-             (n (if (socket-ssl-handle socket)
-                    (cl+ssl::ssl-write (socket-ssl-handle socket)
-                                       data-sap
-                                       len)
-                    (wsys:write fd data-sap len))))
+             (n
+               #+woo-no-ssl
+               (wsys:write fd data-sap len)
+               #-woo-no-ssl
+               (if (socket-ssl-handle socket)
+                   (cl+ssl::ssl-write (socket-ssl-handle socket)
+                                      data-sap
+                                      len)
+                   (wsys:write fd data-sap len))))
         (declare (type fixnum len)
                  (type fixnum n))
         (case n

--- a/src/ev/tcp.lisp
+++ b/src/ev/tcp.lisp
@@ -100,6 +100,9 @@
          (ssl-handle (socket-ssl-handle socket)))
     (loop
       (let ((n
+              #+woo-no-ssl
+              (wsys:read fd (static-vectors:static-vector-pointer *input-buffer*) buffer-len)
+              #-woo-no-ssl
               (if ssl-handle
                   (cl+ssl::ssl-read ssl-handle (static-vectors:static-vector-pointer *input-buffer*) buffer-len)
                   (wsys:read fd (static-vectors:static-vector-pointer *input-buffer*) buffer-len))))

--- a/src/ev/tcp.lisp
+++ b/src/ev/tcp.lisp
@@ -189,16 +189,6 @@
         (cffi:foreign-slot-value *dummy-sockaddr* '(:struct wsock:sockaddr-in) 'wsock::port)))
       (t (values nil nil)))))
 
-(defun make-ssl-handle (client-fd)
-  (cl+ssl::ensure-initialized)
-  (cl+ssl::with-new-ssl (handle)
-    (cl+ssl::install-nonblock-flag client-fd)
-    (cl+ssl::ssl-set-fd handle client-fd)
-    (cl+ssl::ssl-set-accept-state handle)
-    (when cl+ssl:*default-cipher-list*
-      (cl+ssl::ssl-set-cipher-list handle cl+ssl:*default-cipher-list*))
-    handle))
-
 (define-c-callback tcp-accept-cb :void ((evloop :pointer) (listener :pointer) (events :int))
   (declare (ignore evloop events))
   (let* ((fd (io-fd listener))

--- a/src/ev/tcp.lisp
+++ b/src/ev/tcp.lisp
@@ -241,8 +241,7 @@
        (multiple-value-bind (remote-addr remote-port)
            (get-remote-addr-and-port)
          (let ((socket (make-socket :fd client-fd :tcp-read-cb 'tcp-read-cb
-                                    :remote-addr remote-addr :remote-port remote-port
-                                    :ssl-stream (make-ssl-stream client-fd))))
+                                    :remote-addr remote-addr :remote-port remote-port)))
            (let* ((callbacks (callbacks fd))
                   (read-cb (getf callbacks :read-cb))
                   (connect-cb (getf callbacks :connect-cb)))

--- a/src/ssl.lisp
+++ b/src/ssl.lisp
@@ -1,0 +1,32 @@
+(defpackage woo.ssl
+  (:use :cl)
+  (:import-from :cl+ssl
+                :with-new-ssl
+                :install-nonblock-flag
+                :ssl-set-fd
+                :ssl-set-accept-state
+                :*default-cipher-list*
+                :ssl-set-cipher-list
+                :with-pem-password
+                :install-key-and-cert)
+  (:import-from :woo.ev.socket
+                :socket-fd
+                :socket-ssl-handle)
+  (:export :init-ssl-handle))
+(in-package :woo.ssl)
+
+(defun init-ssl-handle (socket ssl-cert-file ssl-key-file ssl-key-password)
+  (let ((client-fd (socket-fd socket)))
+    (with-new-ssl (handle)
+      (install-nonblock-flag client-fd)
+      (ssl-set-fd handle client-fd)
+      (ssl-set-accept-state handle)
+      (when *default-cipher-list*
+        (ssl-set-cipher-list handle *default-cipher-list*))
+      (setf (socket-ssl-handle socket) handle)
+      (with-pem-password ((or ssl-key-password ""))
+        (install-key-and-cert
+         handle
+         ssl-key-file
+         ssl-cert-file))
+      socket)))

--- a/src/woo.lisp
+++ b/src/woo.lisp
@@ -69,6 +69,7 @@
                      ssl-key-file
                      ssl-cert-file
                      ssl-key-password)
+  (declare (ignorable ssl-key-password))
   (assert (and (integerp backlog)
                (plusp backlog)
                (<= backlog 128)))

--- a/t/generate-certificates.sh
+++ b/t/generate-certificates.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+mkdir t/certs
+cd t/certs
+
+openssl genrsa -out localCA.key 2048
+openssl req -batch -new -key localCA.key -out localCA.csr \
+  -subj "/C=JP/ST=Tokyo/L=Chuo-ku/O=\"Woo\"/OU=Development/CN=localhost"
+openssl x509 -req -days 3650 -signkey localCA.key -in localCA.csr -out localCA.crt
+openssl x509 -text -noout -in localCA.crt
+openssl genrsa -out localhost.key 2048
+openssl req -batch -new -key localhost.key -out localhost.csr \
+  -subj "/C=JP/ST=Tokyo/L=Chuo-ku/O=\"Woo\"/OU=Development/CN=localhost"
+echo 'subjectAltName = DNS:localhost, DNS:localhost.localdomain, IP:127.0.0.1, DNS:app, DNS:app.localdomain' > localhost.csx
+openssl x509 -req -days 1825 -CA localCA.crt -CAkey localCA.key -CAcreateserial -in localhost.csr -extfile localhost.csx -out localhost.crt

--- a/t/woo.lisp
+++ b/t/woo.lisp
@@ -6,3 +6,11 @@
 
 (deftest woo-server-tests
   (clack.test.suite:run-server-tests :woo))
+
+(deftest woo-ssl-server-tests
+  (let ((clack.test:*clackup-additional-args*
+          '(:ssl-cert-file #P"t/certs/localhost.crt"
+            :ssl-key-file #P"t/certs/localhost.key"))
+        (dex:*not-verify-ssl* t)
+        (clack.test:*use-https* t))
+    (clack.test.suite:run-server-tests :woo)))

--- a/woo.asd
+++ b/woo.asd
@@ -20,7 +20,8 @@
                #+sbcl "sb-posix"
                #+(and linux (not asdf3)) "uiop"
                #+sbcl "sb-concurrency"
-               #-sbcl "cl-speedy-queue")
+               #-sbcl "cl-speedy-queue"
+               "cl+ssl")
   :components ((:module "src"
                 :components
                 ((:file "woo" :depends-on ("ev" "response" "worker" "signal" "specials" "util"))

--- a/woo.asd
+++ b/woo.asd
@@ -17,11 +17,11 @@
                "trivial-mimes"
                "vom"
                "alexandria"
-               #+sbcl "sb-posix"
-               #+(and linux (not asdf3)) "uiop"
-               #+sbcl "sb-concurrency"
-               #-sbcl "cl-speedy-queue"
-               "cl+ssl")
+               (:feature :sbcl "sb-posix")
+               (:feature (:and :linux (:not :asdf3)) "uiop")
+               (:feature :sbcl "sb-concurrency")
+               (:feature (:not :sbcl) "cl-speedy-queue")
+               (:feature (:not :woo-no-ssl) "cl+ssl"))
   :components ((:module "src"
                 :components
                 ((:file "woo" :depends-on ("ev" "response" "worker" "ssl" "signal" "specials" "util"))
@@ -38,7 +38,9 @@
                    (:file "tcp" :depends-on ("event-loop" "socket" "util" "condition"))
                    (:file "condition")
                    (:file "util")))
-                 (:file "ssl" :depends-on ("ev-packages"))
+                 (:file "ssl"
+                  :depends-on ("ev-packages")
+                  :if-feature (:not :woo-no-ssl))
                  (:module "llsocket"
                   :depends-on ("syscall")
                   :serial t

--- a/woo.asd
+++ b/woo.asd
@@ -24,7 +24,7 @@
                "cl+ssl")
   :components ((:module "src"
                 :components
-                ((:file "woo" :depends-on ("ev" "response" "worker" "signal" "specials" "util"))
+                ((:file "woo" :depends-on ("ev" "response" "worker" "ssl" "signal" "specials" "util"))
                  (:file "response" :depends-on ("ev"))
                  (:file "ev" :depends-on ("ev-packages"))
                  (:file "worker" :depends-on ("ev" "queue" "specials"))
@@ -38,6 +38,7 @@
                    (:file "tcp" :depends-on ("event-loop" "socket" "util" "condition"))
                    (:file "condition")
                    (:file "util")))
+                 (:file "ssl" :depends-on ("ev-packages"))
                  (:module "llsocket"
                   :depends-on ("syscall")
                   :serial t


### PR DESCRIPTION
## Usage

Use SSL key arguments of `woo:run` or `clack:clackup`. 

```common-lisp
(woo:run app
         :ssl-cert-file #P"path/to/cert.pem"
         :ssl-key-file #P"path/to/key.pem"
         :ssl-key-pass "password")

(clack:clackup app
               :ssl-cert-file #P"path/to/cert.pem"
               :ssl-key-file #P"path/to/key.pem"
               :ssl-key-pass "password")
```

To disable the HTTPS support to omit a dependency on CL+SSL, add `woo-no-ssl` to `cl:*features*`.

## TODO

- [x] Basic implementation
- [x] HTTPS for static files
  * **[FUTURE TASK]** Add a flag to use `SSL_sendfile` (Using Kernel TLS) for better performance
- [x] Refactoring
  * Wrap symbol references to internal symbols of cl+ssl
  * Better to reduce conditional flows (socket-ssl-stream)
- [x] Add a feature to disable HTTPS to omit the dependency on cl+ssl
- [x] Run tests for HTTPS
- [x] Proper error code handling on SSL I/O (ssl-read/ssl-write)
- [x] Benchmark to make sure its performance downgrade is limited or permissible
  * Not much difference from the master branch
  * Single thread: HTTP = 61k / HTTPS = 56k
  * 4 threads: HTTPS = 137k / HTTPS = 105k